### PR TITLE
Change optimization sequencing to allow additional rank allocation

### DIFF
--- a/DJIVECode/BlockJointStrucEstimateJPLoadInfo.m
+++ b/DJIVECode/BlockJointStrucEstimateJPLoadInfo.m
@@ -153,12 +153,14 @@ function [Vi, curRanks, angles] = BlockJointStrucEstimateJPLoadInfo(blockIn, dat
         fprintf('Direction %d converges.\n', j)
         Vi = [Vi, opt_v];
         curRanks = curRanks + blockIn';
+        %{
         if any(curRanks + blockIn' > rBars)
             fprintf('There is no room for searching next direction. Stop seraching current joint block.\n')
             searchNext = false;
         else
             fprintf('There is room for searching next direction. Continue...\n')
         end
+        %}
     end
     
     angles = angles(:,1:(size(Vi,2)+1*~any(curRanks + blockIn' > rBars)));

--- a/DJIVECode/DJIVEMainJP.m
+++ b/DJIVECode/DJIVEMainJP.m
@@ -64,7 +64,7 @@ function outstruct = DJIVEMainJP(datablock, paramstruct, truth)
     colCent = 0;
     rowCent = 0;
     figdir = '';
-    filterPerc = 0.5;
+    filterPerc = 1 - (2/(1+sqrt(5))) ; % "Golden Ratio"
     
     if exist('paramstruct', 'var')
         if isfield(paramstruct, 'dataname')
@@ -116,8 +116,6 @@ function outstruct = DJIVEMainJP(datablock, paramstruct, truth)
             rowSpaces{ib} = orth(truth{ib}');
         end
     end
-    
-    goldenRatio = 1 - (2/(1+sqrt(5))) ;
     
     % Step 1: Estimate signal space and perturbation angle
     [VBars, UBars, phiBars, psiBars, EHats, rBars, singVals, singValsHat, rSteps, VVHatCacheBars, UUHatCacheBars] = ...


### PR DESCRIPTION
Remove restriction of only assigning dimensions to a data block up to the total dimension of the signal

Edit the default filtering percentage to "golden ratio" (about 38%) rather than 50%